### PR TITLE
Support component reference by id. Closes: #1

### DIFF
--- a/examples/groups/jobs/bash_stuff/date.rb
+++ b/examples/groups/jobs/bash_stuff/date.rb
@@ -4,7 +4,7 @@ time_resources = @resources.values.select { |r| r.type == :time }
 
 time_resources.each do |r|
   job :date do
-    plan << { get: r.name, trigger: true }
+    plan << { get: r, trigger: true }
     plan << { task: 'print_date', config: {
       platform: 'linux',
       image_resource: { type: 'docker-image', source: { repository: 'busybox' } },

--- a/examples/groups/jobs/bash_stuff/hello.rb
+++ b/examples/groups/jobs/bash_stuff/hello.rb
@@ -4,7 +4,7 @@ time_resources = resources.values.select { |r| r.type == :time }
 
 time_resources.each do |r|
   job :hello do
-    plan << { get: r.name, trigger: true }
+    plan << { get: r, trigger: true }
     plan << { task: 'print_hello', config: {
       platform: 'linux',
       image_resource: { type: 'docker-image', source: { repository: 'busybox' } },

--- a/examples/groups/jobs/git_stuff/log.rb
+++ b/examples/groups/jobs/git_stuff/log.rb
@@ -4,10 +4,10 @@ git_resources = resources.values.select { |r| r.type == :git }
 
 git_resources.each do |r|
   job "git log #{r.name}" do
-    plan << { get: r.name, trigger: true }
+    plan << { get: r, trigger: true }
     task = {
       task: "git log #{r.name}", config: {
-        inputs: [name: r.name],
+        inputs: [name: r],
         platform: 'linux',
         image_resource: { type: 'docker-image', source: { repository: 'alpine/git' } },
         run: {

--- a/examples/groups/jobs/git_stuff/ls.rb
+++ b/examples/groups/jobs/git_stuff/ls.rb
@@ -4,15 +4,15 @@ git_resources = resources.values.select { |r| r.type == :git }
 
 git_resources.each do |r|
   job "ls #{r.name}" do
-    plan << { get: r.name, trigger: true }
+    plan << { get: r, trigger: true }
     task = {
       task: "ls #{r.name}", config: {
-        inputs: [name: r.name],
+        inputs: [name: r],
         platform: 'linux',
         image_resource: { type: 'docker-image', source: { repository: 'alpine/git' } },
         run: {
           path: 'ls',
-          args: [r.name]
+          args: [r]
         }
       }
     }

--- a/examples/shared/wrapper_pipeline.rb
+++ b/examples/shared/wrapper_pipeline.rb
@@ -34,7 +34,7 @@ job 'Goodbye from the Wrapper Pipeline' do |_pipeline|
   last_job = common.jobs.values.last
   last_job.plan.select { |task| task.key? :get }.each do |task|
     task = task.dup
-    task[:passed] = [last_job.name]
+    task[:passed] = [last_job]
     plan << task
   end
   task = {

--- a/lib/rudder/dsl/pipeline.rb
+++ b/lib/rudder/dsl/pipeline.rb
@@ -191,12 +191,19 @@ module Rudder
       #
       def to_h
         h = {
-          'resources' => _convert_h_val(@resources.values),
-          'jobs' => _convert_h_val(@jobs.values)
+          'resources' => p_convert_h_val(@resources.values),
+          'jobs' => p_convert_h_val(@jobs.values)
         }
-        h['groups'] = _convert_h_val(@groups.values) unless @groups.empty?
-        h['resource_types'] = _convert_h_val(@resource_types.values) unless @resource_types.empty?
+        h['groups'] = p_convert_h_val(@groups.values) unless @groups.empty?
+        h['resource_types'] = p_convert_h_val(@resource_types.values) unless @resource_types.empty?
         h
+      end
+
+      #
+      # Wraps {_convert_h_val} since it will always set use_name to false
+      #
+      def p_convert_h_val(hash)
+        _convert_h_val(hash, false)
       end
 
       ##

--- a/lib/rudder/dsl/util.rb
+++ b/lib/rudder/dsl/util.rb
@@ -12,12 +12,15 @@ module Rudder
       # Recursively converts keys and values
       # of a {Hash} to YAML friendly values
       #
+      # @param use_name [Boolean] when true named objects
+      #    are rendered only by name. Otherwise, renders
+      #    to {Hash} (if able), or returns the object itself.
       # @return [Hash] representation of this class
       #
-      def _deep_to_h(hash)
+      def _deep_to_h(hash, use_name = true)
         hash.map do |k, v|
-          k = _convert_h_val(k)
-          v = _convert_h_val(v)
+          k = _convert_h_val(k, use_name)
+          v = _convert_h_val(v, use_name)
           [k, v]
         end.to_h
       end
@@ -26,18 +29,21 @@ module Rudder
       # Converts non-collections to YAML safe strings
       # and collections to collections of YAML safe strings
       #
+      # @param use_name [Boolean] when true named objects
+      #    are rendered only by name. Otherwise, renders
+      #    to {Hash} (if able), or returns the object itself.
       #
-      def _convert_h_val(value)
+      def _convert_h_val(value, use_name = true)
         case value
-        when Hash
-          _deep_to_h(value)
         when Array
-          value.map { |x| _convert_h_val(x) }
+          value.map { |x| _convert_h_val(x, use_name) }
         when Symbol
           value.to_s
         else
-          if value.respond_to? :to_h
-            _deep_to_h(value.to_h)
+          if use_name && value.respond_to?(:name)
+            value.name.to_s
+          elsif value.respond_to? :to_h
+            _deep_to_h(value.to_h, use_name)
           else
             value
           end

--- a/spec/rudder/dsl/util_spec.rb
+++ b/spec/rudder/dsl/util_spec.rb
@@ -4,7 +4,15 @@ require 'rudder/dsl/util'
 require 'spec_helper'
 
 RSpec.describe Rudder::DSL::Util do
-  let(:dummy) { Class.new { include Rudder::DSL::Util }.new }
+  let(:dummy) do
+    Class.new do
+      include Rudder::DSL::Util
+      attr_accessor :name
+      def initialize
+        @name = :dummy_name
+      end
+    end.new
+  end
 
   describe '#_deep_to_h' do
     context 'when provided an empty hash' do
@@ -54,6 +62,13 @@ RSpec.describe Rudder::DSL::Util do
     context 'when provided an integer' do
       it 'returns the same integer' do
         expect(dummy._convert_h_val(1)).to eq(1)
+      end
+    end
+
+    context 'when provided a named object' do
+      it 'renders just the name of the object' do
+        test = { a: dummy }
+        expect(dummy._convert_h_val(test)).to eq('a' => 'dummy_name')
       end
     end
   end


### PR DESCRIPTION
Components can now reference each other as objects
rather than just `String` or `Symbol` names.

Includes:
- Tests
- Example Updates
- Small doc tweaks (all internal methods)