### PR TITLE
Pipeline helpers. Closes #2

### DIFF
--- a/docs/Rudder.html
+++ b/docs/Rudder.html
@@ -372,7 +372,7 @@ handle <code>output</code></p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL.html
+++ b/docs/Rudder/DSL.html
@@ -446,7 +446,7 @@ pipelines</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL/Component.html
+++ b/docs/Rudder/DSL/Component.html
@@ -635,7 +635,7 @@ arguments are provided. Otherwise, <code>nil</code>.</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:38 2019 by
+  Generated on Fri Aug  2 21:10:14 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL/Group.html
+++ b/docs/Rudder/DSL/Group.html
@@ -723,7 +723,7 @@ is nil.</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL/Job.html
+++ b/docs/Rudder/DSL/Job.html
@@ -477,7 +477,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL/Pipeline.html
+++ b/docs/Rudder/DSL/Pipeline.html
@@ -136,11 +136,25 @@ optional arguments, then typically a block.</p>
 out common subsections of pipelines, then merging them into larger
 pipelines.</p>
 
-<h3 id="label-Loading+Individual+Components">Loading Individual Components</h3>
+<h3 id="label-Merging+Pipeline+Components">Merging Pipeline Components</h3>
+
+<p><span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span>&#39;s can merge loaded or defined
+Rudder::DSL:Pipelines&#39;s, Hash&#39;s of components, or Array&#39;s
+of components into the current definition using
+<span class='object_link'><a href="#merge_components-instance_method" title="Rudder::DSL::Pipeline#merge_components (method)">#merge_components</a></span>.</p>
+
+<h3 id="label-Including+Other+Pipelines">Including Other Pipelines</h3>
+
+<p><span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span>&#39;s can include other pipeline definitions using
+<span class='object_link'><a href="#include_pipeline-instance_method" title="Rudder::DSL::Pipeline#include_pipeline (method)">#include_pipeline</a></span>. This is similar to
+Rudder::DSL:Pipeline#load except that all the components are
+automatically included into this <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span></p>
+
+<h3 id="label-Including+Individual+Components">Including Individual Components</h3>
 
 <p>Individual pipeline components can also be defined on a per-file basis and
 then loaded into a <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span> using
-<span class='object_link'><a href="#load_component-instance_method" title="Rudder::DSL::Pipeline#load_component (method)">#load_component</a></span>. This is useful for factoring out
+<span class='object_link'><a href="#include_component-instance_method" title="Rudder::DSL::Pipeline#include_component (method)">#include_component</a></span>. This is useful for factoring out
 common resources for multiple pipeline&#39;s to use.</p>
 
 
@@ -226,7 +240,7 @@ end</code></pre>
 </span>
 <span class='comment'># load the resource into the pipeline. Automatically includes
 </span><span class='comment'># the resource into the resources list with the name :scripts
-</span><span class='id identifier rubyid_load_component'>load_component</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>operations_scripts_resource.rb</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='symbol'>:resource</span><span class='comma'>,</span> <span class='symbol'>:scripts</span>
+</span><span class='id identifier rubyid_include_component'>include_component</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>operations_scripts_resource.rb</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='symbol'>:resource</span><span class='comma'>,</span> <span class='symbol'>:scripts</span>
 
 <span class='id identifier rubyid_job'>job</span> <span class='symbol'>:audit</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_pipeline'>pipeline</span><span class='op'>|</span>
   <span class='id identifier rubyid_plan'>plan</span> <span class='op'>&lt;&lt;</span> <span class='lbrace'>{</span>
@@ -245,6 +259,13 @@ end</code></pre>
     
   </div>
 
+
+  <p class="tag_title">See Also:</p>
+  <ul class="see">
+    
+      <li><span class='object_link'><a href="#merge_components-instance_method" title="Rudder::DSL::Pipeline#merge_components (method)">#merge_components for modes of operation.</a></span></li>
+    
+  </ul>
 
 </div>
 
@@ -377,31 +398,6 @@ end</code></pre>
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#_get_local_component-instance_method" title="#_get_local_component (instance method)">#<strong>_get_local_component</strong>(component)  &#x21d2; Object </a>
-    
-
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'>
-<p>Yikes! Seems like a bad idea - if someone uses the same name twice (say, 1
-resource and 1 job), then this will return one pretty much at random.</p>
-</div></span>
-  
-</li>
-
-      
-        <li class="public ">
-  <span class="summary_signature">
-    
       <a href="#eval-instance_method" title="#eval (instance method)">#<strong>eval</strong>(file_path = nil)  &#x21d2; Rudder::DSL::Pipeline </a>
     
 
@@ -418,6 +414,56 @@ resource and 1 job), then this will return one pretty much at random.</p>
   
     <span class="summary_desc"><div class='inline'>
 <p>Evaluates the given file path.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#include_component-instance_method" title="#include_component (instance method)">#<strong>include_component</strong>(component_path, class_sym, name, *args)  &#x21d2; Object </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Given a path to a component, its class, and any args required to construct
+it, creates a new component.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#include_pipeline-instance_method" title="#include_pipeline (instance method)">#<strong>include_pipeline</strong>(other_pipeline_path)  &#x21d2; nil </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Includes another <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span> from a file into this
+<span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span>.</p>
 </div></span>
   
 </li>
@@ -477,7 +523,7 @@ it.</p>
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#load_component-instance_method" title="#load_component (instance method)">#<strong>load_component</strong>(component_path, class_sym, name, *args)  &#x21d2; Object </a>
+      <a href="#merge_components-instance_method" title="#merge_components (instance method)">#<strong>merge_components</strong>(components)  &#x21d2; nil </a>
     
 
     
@@ -492,8 +538,8 @@ it.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Given a path to a component, its class, and any args required to construct
-it, creates a new component.</p>
+<p>Merges the provided <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span> components into this
+<span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span>.</p>
 </div></span>
   
 </li>
@@ -519,6 +565,30 @@ it, creates a new component.</p>
     <span class="summary_desc"><div class='inline'>
 <p>Populates this <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span> with components and optionally
 fetches defined components.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#p_convert_h_val-instance_method" title="#p_convert_h_val (instance method)">#<strong>p_convert_h_val</strong>(hash)  &#x21d2; Object </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Wraps <span class='object_link'><a href="Util.html#_convert_h_val-instance_method" title="Rudder::DSL::Util#_convert_h_val (method)">Util#_convert_h_val</a></span> since it will always set use_name to false.</p>
 </div></span>
   
 </li>
@@ -751,26 +821,26 @@ Resource Type names to their definitions.</p>
       <pre class="lines">
 
 
-166
-167
-168
-169
-170
-171
-172
-173
-174
-175
-176
-177
-178
-179
-180
-181
-182</pre>
+183
+184
+185
+186
+187
+188
+189
+190
+191
+192
+193
+194
+195
+196
+197
+198
+199</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 166</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 183</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_file_path'>file_path</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>resources:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='comma'>,</span> <span class='label'>jobs:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='comma'>,</span>
                <span class='label'>groups:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='comma'>,</span> <span class='label'>resource_types:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
@@ -892,27 +962,27 @@ Otherwise returns <code>nil</code>.</p>
       <pre class="lines">
 
 
-237
-238
-239
-240
-241
-242
-243
-244
-245
-246
-247
-248
-249
-250
-251
-252
-253
-254</pre>
+261
+262
+263
+264
+265
+266
+267
+268
+269
+270
+271
+272
+273
+274
+275
+276
+277
+278</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 237</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 261</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_method_missing'>method_missing</span><span class='lparen'>(</span><span class='id identifier rubyid_method'>method</span><span class='comma'>,</span> <span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='comma'>,</span> <span class='op'>&amp;</span><span class='id identifier rubyid_component_block'>component_block</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_local_component'>local_component</span> <span class='op'>=</span> <span class='id identifier rubyid__get_local_component'>_get_local_component</span><span class='lparen'>(</span><span class='id identifier rubyid_method'>method</span><span class='rparen'>)</span>
@@ -983,12 +1053,12 @@ Otherwise returns <code>nil</code>.</p>
       <pre class="lines">
 
 
-138
-139
-140</pre>
+155
+156
+157</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 138</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 155</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_groups'>groups</span>
   <span class='ivar'>@groups</span>
@@ -1039,12 +1109,12 @@ Otherwise returns <code>nil</code>.</p>
       <pre class="lines">
 
 
-132
-133
-134</pre>
+149
+150
+151</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 132</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 149</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_jobs'>jobs</span>
   <span class='ivar'>@jobs</span>
@@ -1095,12 +1165,12 @@ Otherwise returns <code>nil</code>.</p>
       <pre class="lines">
 
 
-135
-136
-137</pre>
+152
+153
+154</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 135</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 152</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_resource_types'>resource_types</span>
   <span class='ivar'>@resource_types</span>
@@ -1151,12 +1221,12 @@ Otherwise returns <code>nil</code>.</p>
       <pre class="lines">
 
 
-129
-130
-131</pre>
+146
+147
+148</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 129</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 146</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_resources'>resources</span>
   <span class='ivar'>@resources</span>
@@ -1174,63 +1244,7 @@ Otherwise returns <code>nil</code>.</p>
 
     
       <div class="method_details first">
-  <h3 class="signature first" id="_get_local_component-instance_method">
-  
-    #<strong>_get_local_component</strong>(component)  &#x21d2; <tt>Object</tt> 
-  
-
-  
-
-  
-</h3><div class="docstring">
-  <div class="discussion">
-    
-<p>Yikes! Seems like a bad idea - if someone uses the same name twice (say, 1
-resource and 1 job), then this will return one pretty much at random. TODO:
-Make this not bad Oh well.. TODO: This may be returning a
-non-nil/non-falsey type that causes some issues</p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-
-</div><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-363
-364
-365
-366
-367
-368
-369
-370
-371</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 363</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid__get_local_component'>_get_local_component</span><span class='lparen'>(</span><span class='id identifier rubyid_component'>component</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_component'>component</span> <span class='op'>=</span> <span class='id identifier rubyid_component'>component</span><span class='period'>.</span><span class='id identifier rubyid_to_sym'>to_sym</span>
-  <span class='id identifier rubyid_locals'>locals</span> <span class='op'>=</span> <span class='ivar'>@known_classes</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_m'>m</span><span class='op'>|</span>
-    <span class='id identifier rubyid_m'>m</span><span class='lbracket'>[</span><span class='symbol'>:pipeline_group</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='id identifier rubyid_component'>component</span><span class='rbracket'>]</span>
-  <span class='kw'>end</span><span class='period'>.</span><span class='id identifier rubyid_compact'>compact</span>
-  <span class='comment'># TODO: Add a logger here..
-</span>  <span class='id identifier rubyid_puts'>puts</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Found multiple bindings for: </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_p'>p</span><span class='embexpr_end'>}</span><span class='tstring_content'>. Getting first found</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>unless</span> <span class='id identifier rubyid_locals'>locals</span><span class='period'>.</span><span class='id identifier rubyid_size'>size</span> <span class='op'>&lt;=</span> <span class='int'>1</span>
-  <span class='id identifier rubyid_locals'>locals</span><span class='lbracket'>[</span><span class='int'>0</span><span class='rbracket'>]</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
-      <div class="method_details ">
-  <h3 class="signature " id="eval-instance_method">
+  <h3 class="signature first" id="eval-instance_method">
   
     #<strong>eval</strong>(file_path = nil)  &#x21d2; <tt><span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span></tt> 
   
@@ -1316,20 +1330,20 @@ provided at construction time If both are nil, raises an exception</p>
       <pre class="lines">
 
 
-279
-280
-281
-282
-283
-284
-285
-286
-287
-288
-289</pre>
+303
+304
+305
+306
+307
+308
+309
+310
+311
+312
+313</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 279</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 303</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_eval'>eval</span><span class='lparen'>(</span><span class='id identifier rubyid_file_path'>file_path</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='ivar'>@file_path</span> <span class='op'>=</span> <span class='id identifier rubyid_file_path'>file_path</span> <span class='op'>||</span> <span class='ivar'>@file_path</span>
@@ -1341,6 +1355,247 @@ provided at construction time If both are nil, raises an exception</p>
     <span class='id identifier rubyid_instance_eval'>instance_eval</span> <span class='id identifier rubyid_f'>f</span><span class='period'>.</span><span class='id identifier rubyid_read'>read</span><span class='comma'>,</span> <span class='ivar'>@file_path</span>
   <span class='kw'>end</span>
   <span class='kw'>self</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="include_component-instance_method">
+  
+    #<strong>include_component</strong>(component_path, class_sym, name, *args)  &#x21d2; <tt>Object</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+  <div class="note notetag">
+    <strong>Note:</strong>
+    <div class='inline'>
+<p>This automatically includes the component into this pipeline</p>
+</div>
+  </div>
+
+
+<p>Given a path to a component, its class, and any args required to construct
+it, creates a new component</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>component_path</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>path, relative to this pipeline, containing a <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span> to
+load</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>class_sym</span>
+      
+      
+        <span class='type'>(<tt>Symbol</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>symbol of a <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span>. May be one of: (<code>:job</code>,
+<code>:resource</code>, <code>:resource_type</code>, <code>:group</code>)</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>name</span>
+      
+      
+        <span class='type'>(<tt>String</tt>, <tt>Symbol</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>name to use for the loaded <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span>. Must not be
+<code>nil</code>.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>*args</span>
+      
+      
+        <span class='type'></span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>any additional arguments to pass to the <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span>
+constructor.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Raises:</p>
+<ul class="raise">
+  
+    <li>
+      
+      
+        <span class='type'></span>
+      
+      
+      
+        
+        <div class='inline'>
+<p>RuntimeError if <code>name</code> is <code>nil</code> or an uknown
+<code>class_sym</code> is provided.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+371
+372
+373
+374
+375
+376
+377
+378
+379
+380</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 371</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_include_component'>include_component</span><span class='lparen'>(</span><span class='id identifier rubyid_component_path'>component_path</span><span class='comma'>,</span> <span class='id identifier rubyid_class_sym'>class_sym</span><span class='comma'>,</span> <span class='id identifier rubyid_name'>name</span><span class='comma'>,</span> <span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_raise'>raise</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Unable to load </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_class_sym'>class_sym</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>unless</span> <span class='ivar'>@known_classes</span><span class='period'>.</span><span class='id identifier rubyid_keys'>keys</span><span class='period'>.</span><span class='id identifier rubyid_include?'>include?</span> <span class='id identifier rubyid_class_sym'>class_sym</span>
+  <span class='id identifier rubyid_raise'>raise</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Name must not be nil</span><span class='tstring_end'>&#39;</span></span> <span class='kw'>if</span> <span class='id identifier rubyid_name'>name</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
+
+  <span class='id identifier rubyid_full_path'>full_path</span> <span class='op'>=</span> <span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_join'>join</span><span class='lparen'>(</span><span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_dirname'>dirname</span><span class='lparen'>(</span><span class='ivar'>@file_path</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='id identifier rubyid_component_path'>component_path</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_component'>component</span> <span class='op'>=</span> <span class='ivar'>@known_classes</span><span class='lbracket'>[</span><span class='id identifier rubyid_class_sym'>class_sym</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='symbol'>:clazz</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_name'>name</span><span class='comma'>,</span> <span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_component'>component</span><span class='period'>.</span><span class='id identifier rubyid_instance_eval'>instance_eval</span> <span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_read'>read</span><span class='lparen'>(</span><span class='id identifier rubyid_full_path'>full_path</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='id identifier rubyid_full_path'>full_path</span>
+  <span class='ivar'>@known_classes</span><span class='lbracket'>[</span><span class='id identifier rubyid_class_sym'>class_sym</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='symbol'>:pipeline_group</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='id identifier rubyid_name'>name</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid_component'>component</span>
+  <span class='id identifier rubyid_component'>component</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="include_pipeline-instance_method">
+  
+    #<strong>include_pipeline</strong>(other_pipeline_path)  &#x21d2; <tt>nil</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+  <div class="note notetag">
+    <strong>Note:</strong>
+    <div class='inline'>
+<p>Any component provided that has an overlapping name with a previously
+defined component in this pipeline will override the previous definition</p>
+</div>
+  </div>
+
+
+<p>Includes another <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span> from a file into this
+<span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span>.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>other_pipeline_path</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>path to the <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span> definition</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>nil</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+393
+394
+395
+396</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 393</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_include_pipeline'>include_pipeline</span><span class='lparen'>(</span><span class='id identifier rubyid_other_pipeline_path'>other_pipeline_path</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_pipeline'>pipeline</span> <span class='op'>=</span> <span class='id identifier rubyid_load'>load</span> <span class='id identifier rubyid_other_pipeline_path'>other_pipeline_path</span>
+  <span class='id identifier rubyid_merge_components'>merge_components</span><span class='lparen'>(</span><span class='id identifier rubyid_pipeline'>pipeline</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -1480,24 +1735,24 @@ the other <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (cla
       <pre class="lines">
 
 
-314
-315
-316
-317
-318
-319
-320
-321
-322
-323
-324
-325
-326
-327
-328</pre>
+338
+339
+340
+341
+342
+343
+344
+345
+346
+347
+348
+349
+350
+351
+352</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 314</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 338</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_load'>load</span><span class='lparen'>(</span><span class='id identifier rubyid_other_pipeline_path'>other_pipeline_path</span><span class='comma'>,</span> <span class='label'>resources:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='comma'>,</span> <span class='label'>resource_types:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='comma'>,</span>
          <span class='label'>jobs:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='comma'>,</span> <span class='label'>groups:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
@@ -1520,9 +1775,9 @@ the other <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (cla
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="load_component-instance_method">
+  <h3 class="signature " id="merge_components-instance_method">
   
-    #<strong>load_component</strong>(component_path, class_sym, name, *args)  &#x21d2; <tt>Object</tt> 
+    #<strong>merge_components</strong>(components)  &#x21d2; <tt>nil</tt> 
   
 
   
@@ -1531,10 +1786,36 @@ the other <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (cla
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Given a path to a component, its class, and any args required to construct
-it, creates a new component</p>
+  <div class="note notetag">
+    <strong>Note:</strong>
+    <div class='inline'>
+<p>Any component provided that has an overlapping name with a previously
+defined component in this pipeline will override the previous definition</p>
+</div>
+  </div>
 
-<p>Note that this automatically includes the component into this pipeline</p>
+
+<p>Merges the provided <span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span> components into this
+<span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span>.</p>
+
+<h2 id="label-Modes+of+Operation-3A">Modes of Operation:</h2>
+<ul><li>
+<p><span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span>:</p>
+</li></ul>
+
+<p>When provided a Pipeline, merges all like components into this Pipeline</p>
+<ul><li>
+<p>Hash&lt;String, Component&gt;:</p>
+</li></ul>
+
+<p>When provided a Hash, merges all the components into the like Hash in this
+Pipeline</p>
+<ul><li>
+<p>Array&lt;Component&gt;:</p>
+</li></ul>
+
+<p>When provided an Array, merges all Components into this Pipeline. Inserts
+components into their respective Pipeline group by class.</p>
 
 
   </div>
@@ -1545,88 +1826,48 @@ it, creates a new component</p>
   
     <li>
       
-        <span class='name'>component_path</span>
+        <span class='name'>components</span>
       
       
-        <span class='type'>(<tt>String</tt>)</span>
-      
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>path, relative to this pipeline, containing a <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span> to
-load</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>class_sym</span>
-      
-      
-        <span class='type'>(<tt>Symbol</tt>)</span>
+        <span class='type'>(<tt>{<span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Rudder::DSL::Pipeline</a></span>}</tt>, <tt>Hash</tt>, <tt>Array</tt>)</span>
       
       
       
         &mdash;
         <div class='inline'>
-<p>symbol of a <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span>. May be one of: (<code>:job</code>,
-<code>:resource</code>, <code>:resource_type</code>, <code>:group</code>)</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>name</span>
-      
-      
-        <span class='type'>(<tt>String</tt>, <tt>Symbol</tt>)</span>
-      
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>name to use for the loaded <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span>. Must not be
-<code>nil</code>.</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>*args</span>
-      
-      
-        <span class='type'></span>
-      
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>any additional arguments to pass to the <span class='object_link'><a href="Component.html" title="Rudder::DSL::Component (class)">Component</a></span>
-constructor.</p>
+<p>See Modes of Operation for details</p>
 </div>
       
     </li>
   
 </ul>
 
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>nil</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
 <p class="tag_title">Raises:</p>
 <ul class="raise">
   
     <li>
       
       
-        <span class='type'></span>
+        <span class='type'>(<tt>RuntimeError</tt>)</span>
       
       
       
-        
+        &mdash;
         <div class='inline'>
-<p>RuntimeError if <code>name</code> is <code>nil</code> or an uknown
-<code>class_sym</code> is provided.</p>
+<p>when type provided is unsupported</p>
 </div>
       
     </li>
@@ -1639,29 +1880,66 @@ constructor.</p>
       <pre class="lines">
 
 
-347
-348
-349
-350
-351
-352
-353
-354
-355
-356</pre>
+425
+426
+427
+428
+429
+430
+431
+432</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 347</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 425</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_load_component'>load_component</span><span class='lparen'>(</span><span class='id identifier rubyid_component_path'>component_path</span><span class='comma'>,</span> <span class='id identifier rubyid_class_sym'>class_sym</span><span class='comma'>,</span> <span class='id identifier rubyid_name'>name</span><span class='comma'>,</span> <span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_raise'>raise</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Unable to load </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_class_sym'>class_sym</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>unless</span> <span class='ivar'>@known_classes</span><span class='period'>.</span><span class='id identifier rubyid_keys'>keys</span><span class='period'>.</span><span class='id identifier rubyid_include?'>include?</span> <span class='id identifier rubyid_class_sym'>class_sym</span>
-  <span class='id identifier rubyid_raise'>raise</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Name must not be nil</span><span class='tstring_end'>&#39;</span></span> <span class='kw'>if</span> <span class='id identifier rubyid_name'>name</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_merge_components'>merge_components</span><span class='lparen'>(</span><span class='id identifier rubyid_components'>components</span><span class='rparen'>)</span>
+  <span class='kw'>case</span> <span class='id identifier rubyid_components'>components</span>
+  <span class='kw'>when</span> <span class='const'><span class='object_link'><a href="" title="Rudder::DSL::Pipeline (class)">Pipeline</a></span></span> <span class='kw'>then</span> <span class='id identifier rubyid__merge_pipeline'>_merge_pipeline</span><span class='lparen'>(</span><span class='id identifier rubyid_components'>components</span><span class='rparen'>)</span>
+  <span class='kw'>when</span> <span class='const'>Hash</span> <span class='kw'>then</span> <span class='id identifier rubyid__merge_hash'>_merge_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_components'>components</span><span class='rparen'>)</span>
+  <span class='kw'>when</span> <span class='const'>Array</span> <span class='kw'>then</span> <span class='id identifier rubyid__merge_array'>_merge_array</span><span class='lparen'>(</span><span class='id identifier rubyid_components'>components</span><span class='rparen'>)</span>
+  <span class='kw'>else</span> <span class='id identifier rubyid_raise'>raise</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Unable to merge #{components}: unsupported type</span><span class='tstring_end'>&#39;</span></span>
+  <span class='kw'>end</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="p_convert_h_val-instance_method">
+  
+    #<strong>p_convert_h_val</strong>(hash)  &#x21d2; <tt>Object</tt> 
+  
 
-  <span class='id identifier rubyid_full_path'>full_path</span> <span class='op'>=</span> <span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_join'>join</span><span class='lparen'>(</span><span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_dirname'>dirname</span><span class='lparen'>(</span><span class='ivar'>@file_path</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='id identifier rubyid_component_path'>component_path</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_component'>component</span> <span class='op'>=</span> <span class='ivar'>@known_classes</span><span class='lbracket'>[</span><span class='id identifier rubyid_class_sym'>class_sym</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='symbol'>:clazz</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_name'>name</span><span class='comma'>,</span> <span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_component'>component</span><span class='period'>.</span><span class='id identifier rubyid_instance_eval'>instance_eval</span> <span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_read'>read</span><span class='lparen'>(</span><span class='id identifier rubyid_full_path'>full_path</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='id identifier rubyid_full_path'>full_path</span>
-  <span class='ivar'>@known_classes</span><span class='lbracket'>[</span><span class='id identifier rubyid_class_sym'>class_sym</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='symbol'>:pipeline_group</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='id identifier rubyid_name'>name</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid_component'>component</span>
-  <span class='id identifier rubyid_component'>component</span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Wraps <span class='object_link'><a href="Util.html#_convert_h_val-instance_method" title="Rudder::DSL::Util#_convert_h_val (method)">Util#_convert_h_val</a></span> since it will always set use_name to false</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+222
+223
+224</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 222</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_p_convert_h_val'>p_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='comma'>,</span> <span class='kw'>false</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -1705,12 +1983,12 @@ constructor.</p>
       <pre class="lines">
 
 
-265
-266
-267</pre>
+289
+290
+291</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 265</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 289</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_respond_to?'>respond_to?</span><span class='lparen'>(</span><span class='id identifier rubyid_name'>name</span><span class='comma'>,</span> <span class='id identifier rubyid__include_all'>_include_all</span> <span class='op'>=</span> <span class='kw'>true</span><span class='rparen'>)</span>
   <span class='ivar'>@known_classes</span><span class='period'>.</span><span class='id identifier rubyid_key?'>key?</span> <span class='id identifier rubyid_name'>name</span>
@@ -1764,12 +2042,12 @@ constructor.</p>
       <pre class="lines">
 
 
-261
-262
-263</pre>
+285
+286
+287</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 261</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 285</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_respond_to_missing?'>respond_to_missing?</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid__'>_</span><span class='rparen'>)</span>
   <span class='kw'>true</span>
@@ -1827,26 +2105,26 @@ rendering at all.</p>
       <pre class="lines">
 
 
-192
-193
-194
-195
-196
-197
-198
-199
-200</pre>
+209
+210
+211
+212
+213
+214
+215
+216
+217</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 192</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/pipeline.rb', line 209</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_h'>to_h</span>
   <span class='id identifier rubyid_h'>h</span> <span class='op'>=</span> <span class='lbrace'>{</span>
-    <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>resources</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@resources</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span><span class='comma'>,</span>
-    <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>jobs</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@jobs</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span>
+    <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>resources</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='id identifier rubyid_p_convert_h_val'>p_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@resources</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span><span class='comma'>,</span>
+    <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>jobs</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='id identifier rubyid_p_convert_h_val'>p_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@jobs</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span>
   <span class='rbrace'>}</span>
-  <span class='id identifier rubyid_h'>h</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>groups</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@groups</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span> <span class='kw'>unless</span> <span class='ivar'>@groups</span><span class='period'>.</span><span class='id identifier rubyid_empty?'>empty?</span>
-  <span class='id identifier rubyid_h'>h</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>resource_types</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@resource_types</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span> <span class='kw'>unless</span> <span class='ivar'>@resource_types</span><span class='period'>.</span><span class='id identifier rubyid_empty?'>empty?</span>
+  <span class='id identifier rubyid_h'>h</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>groups</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid_p_convert_h_val'>p_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@groups</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span> <span class='kw'>unless</span> <span class='ivar'>@groups</span><span class='period'>.</span><span class='id identifier rubyid_empty?'>empty?</span>
+  <span class='id identifier rubyid_h'>h</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>resource_types</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid_p_convert_h_val'>p_convert_h_val</span><span class='lparen'>(</span><span class='ivar'>@resource_types</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='rparen'>)</span> <span class='kw'>unless</span> <span class='ivar'>@resource_types</span><span class='period'>.</span><span class='id identifier rubyid_empty?'>empty?</span>
   <span class='id identifier rubyid_h'>h</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -1859,7 +2137,7 @@ rendering at all.</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:38 2019 by
+  Generated on Fri Aug  2 21:10:14 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL/Resource.html
+++ b/docs/Rudder/DSL/Resource.html
@@ -574,7 +574,7 @@ without knowing it&#39;s underlying concourse name.</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:38 2019 by
+  Generated on Fri Aug  2 21:10:14 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL/ResourceType.html
+++ b/docs/Rudder/DSL/ResourceType.html
@@ -213,7 +213,7 @@ community defined.</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:38 2019 by
+  Generated on Fri Aug  2 21:10:14 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/Rudder/DSL/Util.html
+++ b/docs/Rudder/DSL/Util.html
@@ -119,7 +119,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#_convert_h_val-instance_method" title="#_convert_h_val (instance method)">#<strong>_convert_h_val</strong>(value)  &#x21d2; Object </a>
+      <a href="#_convert_h_val-instance_method" title="#_convert_h_val (instance method)">#<strong>_convert_h_val</strong>(value, use_name = true)  &#x21d2; Object </a>
     
 
     
@@ -144,7 +144,7 @@ collections of YAML safe strings.</p>
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#_deep_to_h-instance_method" title="#_deep_to_h (instance method)">#<strong>_deep_to_h</strong>(hash)  &#x21d2; Hash </a>
+      <a href="#_deep_to_h-instance_method" title="#_deep_to_h (instance method)">#<strong>_deep_to_h</strong>(hash, use_name = true)  &#x21d2; Hash </a>
     
 
     
@@ -177,7 +177,7 @@ collections of YAML safe strings.</p>
       <div class="method_details first">
   <h3 class="signature first" id="_convert_h_val-instance_method">
   
-    #<strong>_convert_h_val</strong>(value)  &#x21d2; <tt>Object</tt> 
+    #<strong>_convert_h_val</strong>(value, use_name = true)  &#x21d2; <tt>Object</tt> 
   
 
   
@@ -193,7 +193,30 @@ collections of YAML safe strings</p>
   </div>
 </div>
 <div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
+    <li>
+      
+        <span class='name'>use_name</span>
+      
+      
+        <span class='type'>(<tt>Boolean</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>true</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>when true named objects are rendered only by name. Otherwise, renders to
+Hash (if able), or returns the object itself.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
 
 </div><table class="source_code">
   <tr>
@@ -201,12 +224,6 @@ collections of YAML safe strings</p>
       <pre class="lines">
 
 
-30
-31
-32
-33
-34
-35
 36
 37
 38
@@ -216,22 +233,28 @@ collections of YAML safe strings</p>
 42
 43
 44
-45</pre>
+45
+46
+47
+48
+49
+50
+51</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/util.rb', line 30</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/util.rb', line 36</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='comma'>,</span> <span class='id identifier rubyid_use_name'>use_name</span> <span class='op'>=</span> <span class='kw'>true</span><span class='rparen'>)</span>
   <span class='kw'>case</span> <span class='id identifier rubyid_value'>value</span>
-  <span class='kw'>when</span> <span class='const'>Hash</span>
-    <span class='id identifier rubyid__deep_to_h'>_deep_to_h</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
   <span class='kw'>when</span> <span class='const'>Array</span>
-    <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_x'>x</span><span class='op'>|</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='rparen'>)</span> <span class='rbrace'>}</span>
+    <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_x'>x</span><span class='op'>|</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='comma'>,</span> <span class='id identifier rubyid_use_name'>use_name</span><span class='rparen'>)</span> <span class='rbrace'>}</span>
   <span class='kw'>when</span> <span class='const'>Symbol</span>
     <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
   <span class='kw'>else</span>
-    <span class='kw'>if</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_respond_to?'>respond_to?</span> <span class='symbol'>:to_h</span>
-      <span class='id identifier rubyid__deep_to_h'>_deep_to_h</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_h'>to_h</span><span class='rparen'>)</span>
+    <span class='kw'>if</span> <span class='id identifier rubyid_use_name'>use_name</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_respond_to?'>respond_to?</span><span class='lparen'>(</span><span class='symbol'>:name</span><span class='rparen'>)</span>
+      <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_name'>name</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
+    <span class='kw'>elsif</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_respond_to?'>respond_to?</span> <span class='symbol'>:to_h</span>
+      <span class='id identifier rubyid__deep_to_h'>_deep_to_h</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_h'>to_h</span><span class='comma'>,</span> <span class='id identifier rubyid_use_name'>use_name</span><span class='rparen'>)</span>
     <span class='kw'>else</span>
       <span class='id identifier rubyid_value'>value</span>
     <span class='kw'>end</span>
@@ -245,7 +268,7 @@ collections of YAML safe strings</p>
       <div class="method_details ">
   <h3 class="signature " id="_deep_to_h-instance_method">
   
-    #<strong>_deep_to_h</strong>(hash)  &#x21d2; <tt>Hash</tt> 
+    #<strong>_deep_to_h</strong>(hash, use_name = true)  &#x21d2; <tt>Hash</tt> 
   
 
   
@@ -260,7 +283,30 @@ collections of YAML safe strings</p>
   </div>
 </div>
 <div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
+    <li>
+      
+        <span class='name'>use_name</span>
+      
+      
+        <span class='type'>(<tt>Boolean</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>true</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>when true named objects are rendered only by name. Otherwise, renders to
+Hash (if able), or returns the object itself.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
 <p class="tag_title">Returns:</p>
 <ul class="return">
   
@@ -286,21 +332,21 @@ collections of YAML safe strings</p>
       <pre class="lines">
 
 
-17
-18
-19
 20
 21
 22
-23</pre>
+23
+24
+25
+26</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/util.rb', line 17</span>
+      <pre class="code"><span class="info file"># File 'lib/rudder/dsl/util.rb', line 20</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid__deep_to_h'>_deep_to_h</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid__deep_to_h'>_deep_to_h</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='comma'>,</span> <span class='id identifier rubyid_use_name'>use_name</span> <span class='op'>=</span> <span class='kw'>true</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_hash'>hash</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_k'>k</span><span class='comma'>,</span> <span class='id identifier rubyid_v'>v</span><span class='op'>|</span>
-    <span class='id identifier rubyid_k'>k</span> <span class='op'>=</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_k'>k</span><span class='rparen'>)</span>
-    <span class='id identifier rubyid_v'>v</span> <span class='op'>=</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_v'>v</span><span class='rparen'>)</span>
+    <span class='id identifier rubyid_k'>k</span> <span class='op'>=</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_k'>k</span><span class='comma'>,</span> <span class='id identifier rubyid_use_name'>use_name</span><span class='rparen'>)</span>
+    <span class='id identifier rubyid_v'>v</span> <span class='op'>=</span> <span class='id identifier rubyid__convert_h_val'>_convert_h_val</span><span class='lparen'>(</span><span class='id identifier rubyid_v'>v</span><span class='comma'>,</span> <span class='id identifier rubyid_use_name'>use_name</span><span class='rparen'>)</span>
     <span class='lbracket'>[</span><span class='id identifier rubyid_k'>k</span><span class='comma'>,</span> <span class='id identifier rubyid_v'>v</span><span class='rbracket'>]</span>
   <span class='kw'>end</span><span class='period'>.</span><span class='id identifier rubyid_to_h'>to_h</span>
 <span class='kw'>end</span></pre>
@@ -314,7 +360,7 @@ collections of YAML safe strings</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -201,7 +201,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -190,7 +190,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -190,7 +190,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/docs/method_list.html
+++ b/docs/method_list.html
@@ -62,21 +62,13 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Rudder/DSL/Pipeline.html#_get_local_component-instance_method" title="Rudder::DSL::Pipeline#_get_local_component (method)">#_get_local_component</a></span>
-      <small>Rudder::DSL::Pipeline</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Job.html#_inner_hash-instance_method" title="Rudder::DSL::Job#_inner_hash (method)">#_inner_hash</a></span>
       <small>Rudder::DSL::Job</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Resource.html#_inner_hash-instance_method" title="Rudder::DSL::Resource#_inner_hash (method)">#_inner_hash</a></span>
       <small>Rudder::DSL::Resource</small>
@@ -84,7 +76,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Component.html#_inner_hash-instance_method" title="Rudder::DSL::Component#_inner_hash (method)">#_inner_hash</a></span>
       <small>Rudder::DSL::Component</small>
@@ -92,7 +84,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder.html#compile-class_method" title="Rudder.compile (method)">compile</a></span>
       <small>Rudder</small>
@@ -100,7 +92,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder.html#dump-class_method" title="Rudder.dump (method)">dump</a></span>
       <small>Rudder</small>
@@ -108,7 +100,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Pipeline.html#eval-instance_method" title="Rudder::DSL::Pipeline#eval (method)">#eval</a></span>
       <small>Rudder::DSL::Pipeline</small>
@@ -116,7 +108,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL.html#eval_from_file-class_method" title="Rudder::DSL.eval_from_file (method)">eval_from_file</a></span>
       <small>Rudder::DSL</small>
@@ -124,7 +116,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL.html#from_file-class_method" title="Rudder::DSL.from_file (method)">from_file</a></span>
       <small>Rudder::DSL</small>
@@ -132,7 +124,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Pipeline.html#groups-instance_method" title="Rudder::DSL::Pipeline#groups (method)">#groups</a></span>
       <small>Rudder::DSL::Pipeline</small>
@@ -140,7 +132,23 @@
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Rudder/DSL/Pipeline.html#include_component-instance_method" title="Rudder::DSL::Pipeline#include_component (method)">#include_component</a></span>
+      <small>Rudder::DSL::Pipeline</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Rudder/DSL/Pipeline.html#include_pipeline-instance_method" title="Rudder::DSL::Pipeline#include_pipeline (method)">#include_pipeline</a></span>
+      <small>Rudder::DSL::Pipeline</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Job.html#initialize-instance_method" title="Rudder::DSL::Job#initialize (method)">#initialize</a></span>
       <small>Rudder::DSL::Job</small>
@@ -148,7 +156,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Group.html#initialize-instance_method" title="Rudder::DSL::Group#initialize (method)">#initialize</a></span>
       <small>Rudder::DSL::Group</small>
@@ -156,7 +164,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Pipeline.html#initialize-instance_method" title="Rudder::DSL::Pipeline#initialize (method)">#initialize</a></span>
       <small>Rudder::DSL::Pipeline</small>
@@ -164,7 +172,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Resource.html#initialize-instance_method" title="Rudder::DSL::Resource#initialize (method)">#initialize</a></span>
       <small>Rudder::DSL::Resource</small>
@@ -172,7 +180,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Group.html#job-instance_method" title="Rudder::DSL::Group#job (method)">#job</a></span>
       <small>Rudder::DSL::Group</small>
@@ -180,7 +188,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Group.html#jobs-instance_method" title="Rudder::DSL::Group#jobs (method)">#jobs</a></span>
       <small>Rudder::DSL::Group</small>
@@ -188,7 +196,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Pipeline.html#jobs-instance_method" title="Rudder::DSL::Pipeline#jobs (method)">#jobs</a></span>
       <small>Rudder::DSL::Pipeline</small>
@@ -196,7 +204,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Pipeline.html#load-instance_method" title="Rudder::DSL::Pipeline#load (method)">#load</a></span>
       <small>Rudder::DSL::Pipeline</small>
@@ -204,15 +212,15 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Rudder/DSL/Pipeline.html#load_component-instance_method" title="Rudder::DSL::Pipeline#load_component (method)">#load_component</a></span>
+      <span class='object_link'><a href="Rudder/DSL/Pipeline.html#merge_components-instance_method" title="Rudder::DSL::Pipeline#merge_components (method)">#merge_components</a></span>
       <small>Rudder::DSL::Pipeline</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Pipeline.html#method_missing-instance_method" title="Rudder::DSL::Pipeline#method_missing (method)">#method_missing</a></span>
       <small>Rudder::DSL::Pipeline</small>
@@ -220,7 +228,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Component.html#method_missing-instance_method" title="Rudder::DSL::Component#method_missing (method)">#method_missing</a></span>
       <small>Rudder::DSL::Component</small>
@@ -228,10 +236,18 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Rudder/DSL/Group.html#name-instance_method" title="Rudder::DSL::Group#name (method)">#name</a></span>
       <small>Rudder::DSL::Group</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Rudder/DSL/Pipeline.html#p_convert_h_val-instance_method" title="Rudder::DSL::Pipeline#p_convert_h_val (method)">#p_convert_h_val</a></span>
+      <small>Rudder::DSL::Pipeline</small>
     </div>
   </li>
   

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Aug  2 15:35:37 2019 by
+  Generated on Fri Aug  2 21:10:13 2019 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.20 (ruby-2.5.1).
 </div>

--- a/examples/groups/groups_pipeline.rb
+++ b/examples/groups/groups_pipeline.rb
@@ -10,7 +10,7 @@ relative_files('resources/*').each do |path|
   # Pipline#load includes always loads files relative to where itself, so
   # we need to remove the parent directory from this path
   res = load path.sub(@parent_dir, '')
-  resources.merge! res.resources
+  merge_components res.resources
 end
 
 # Load all the jobs and stick them in groups by directory
@@ -20,7 +20,7 @@ relative_files('jobs/*').each do |group_dir|
     Dir[File.join(group_dir, '*')].each do |job_path|
       parent_dir = File.dirname __FILE__
       job_pipe = pipeline.load(job_path.sub(parent_dir, ''), resources: pipeline.resources)
-      pipeline.jobs.merge! job_pipe.jobs
+      pipeline.merge_components job_pipe.jobs
       job_pipe.jobs.keys.each { |job_name| job job_name }
     end
   end

--- a/examples/includes/includes_pipeline.rb
+++ b/examples/includes/includes_pipeline.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-load_component 'resources/rudder_git.rb', :resource, :rudder_git
+include_component 'resources/rudder_git.rb', :resource, :rudder_git
 
-job = load_component 'jobs/log.rb', :job, :log_rudder_git
+job = include_component 'jobs/log.rb', :job, :log_rudder_git
 job.plan.insert(0, get: :rudder_git, trigger: true)

--- a/examples/shared/borrows_pipeline.rb
+++ b/examples/shared/borrows_pipeline.rb
@@ -8,7 +8,7 @@ end
 
 # Borrow any git resources defined in common
 git_resources = common.resources.select { |_name, r| r.type == :git }
-resources.merge! git_resources
+merge_components git_resources
 
 job 'Just borrowing the git resource' do
   git_names = git_resources.keys

--- a/examples/shared/wrapper_pipeline.rb
+++ b/examples/shared/wrapper_pipeline.rb
@@ -11,8 +11,7 @@ get_timer_task = { get: :timer, trigger: true }
 start_plan = common.jobs.values.first.plan
 start_plan << get_timer_task
 
-resources.merge! common.resources
-jobs     .merge! common.jobs
+merge_components common
 
 job 'An extra job that the wrapper pipeline requires' do
   plan << get_timer_task

--- a/lib/rudder/dsl/pipeline.rb
+++ b/lib/rudder/dsl/pipeline.rb
@@ -88,7 +88,7 @@ module Rudder
     # === Loading Individual Components
     # Individual pipeline components can also be defined on a per-file
     # basis and then loaded into a {Rudder::DSL::Pipeline} using
-    # {Rudder::DSL::Pipeline#load_component}. This is useful for factoring
+    # {Rudder::DSL::Pipeline#include_component}. This is useful for factoring
     # out common resources for multiple pipeline's to use.
     #
     # @example Loading / Importing Individual Components
@@ -106,7 +106,7 @@ module Rudder
     #
     #   # load the resource into the pipeline. Automatically includes
     #   # the resource into the resources list with the name :scripts
-    #   load_component 'operations_scripts_resource.rb', :resource, :scripts
+    #   include_component 'operations_scripts_resource.rb', :resource, :scripts
     #
     #   job :audit do |pipeline|
     #     plan << {
@@ -351,7 +351,7 @@ module Rudder
       #             constructor.
       # @raise RuntimeError if +name+ is +nil+ or an uknown +class_sym+ is provided.
       #
-      def load_component(component_path, class_sym, name, *args)
+      def include_component(component_path, class_sym, name, *args)
         raise "Unable to load #{class_sym}" unless @known_classes.keys.include? class_sym
         raise 'Name must not be nil' if name.nil?
 

--- a/spec/rudder/dsl/pipeline_spec.rb
+++ b/spec/rudder/dsl/pipeline_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe Rudder::DSL::Pipeline do
     end
   end
 
-  describe '#load_component' do
+  describe '#include_component' do
     it 'includes a component from disk into self' do
-      pipeline.load_component 'sample_resource.rb', :resource, :test_resource
+      pipeline.include_component 'sample_resource.rb', :resource, :test_resource
       expected = {
         'jobs' => [],
         'resources' => [


### PR DESCRIPTION
Pipeline helper methods. 
    
Methods added:
 - #merge_components: supports pipelines, arrays, and hashes
 - #include_pipeline: loads pipelines directly into current on
    
Updated docs and examples.
